### PR TITLE
Readme fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 - `pip install -e discord_bot` to install the discord bot,
 
 - streamlit run with: `streamlit run components/pages.py`
-- django admin run with: `DEBUG=true python thetower\dtower\manage.py runserver`
+- django admin run with: `cd thetower/dtower && DEBUG=true python manage.py runserver`
 
 - `db.sqlite3` goes to `thetower/dtower` folder
 - `uploads` csvs folder go to `thetower/dtower`:

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 - `pip install -e thetower` to install the django stuff,
 - `pip install -e discord_bot` to install the discord bot,
 
-- run with: `streamlit run components/tourney.py`
+- streamlit run with: `streamlit run components/pages.py`
 - django admin run with: `cd thetower/dtower && DEBUG=true python manage.py runserver`
 
 - `db.sqlite3` goes to `thetower/dtower` folder

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 - `pip install -e discord_bot` to install the discord bot,
 
 - streamlit run with: `streamlit run components/pages.py`
-- django admin run with: `cd thetower/dtower && DEBUG=true python manage.py runserver`
+- django admin run with: `DEBUG=true python thetower\dtower\manage.py runserver`
 
 - `db.sqlite3` goes to `thetower/dtower` folder
 - `uploads` csvs folder go to `thetower/dtower`:


### PR DESCRIPTION
Do we require using dtower as a working directory for django or can we just run it via direct path?  It seems to run fine for me after this patch.