### PR TITLE
Live results with less delay

### DIFF
--- a/thetower/dtower/tourney_results/get_live_results.py
+++ b/thetower/dtower/tourney_results/get_live_results.py
@@ -22,7 +22,7 @@ logging.basicConfig(level=logging.INFO)
 
 def get_current_time__game_server():
     """Game server runs on utc time and we want live results right away, minus other built-in delays."""
-    return datetime.timezone.utc
+    return datetime.datetime.now(datetime.UTC)
 
 
 def get_date_offset() -> int:

--- a/thetower/dtower/tourney_results/get_live_results.py
+++ b/thetower/dtower/tourney_results/get_live_results.py
@@ -21,8 +21,8 @@ logging.basicConfig(level=logging.INFO)
 
 
 def get_current_time__game_server():
-    """Game server runs on utc time, but we don't want to try accessing results until 1 hour after the tourney is done."""
-    return datetime.datetime.utcnow() - datetime.timedelta(hours=1)
+    """Game server runs on utc time and we want live results right away, minus other built-in delays."""
+    return datetime.datetime.utcnow()
 
 
 def get_date_offset() -> int:

--- a/thetower/dtower/tourney_results/get_live_results.py
+++ b/thetower/dtower/tourney_results/get_live_results.py
@@ -22,7 +22,7 @@ logging.basicConfig(level=logging.INFO)
 
 def get_current_time__game_server():
     """Game server runs on utc time and we want live results right away, minus other built-in delays."""
-    return datetime.datetime.utcnow()
+    return datetime.timezone.utc
 
 
 def get_date_offset() -> int:

--- a/thetower/dtower/tourney_results/get_results.py
+++ b/thetower/dtower/tourney_results/get_results.py
@@ -22,7 +22,7 @@ logging.basicConfig(level=logging.INFO)
 
 def get_current_time__game_server():
     """Game server runs on utc time, but we don't want to try accessing results until 1 hour after the tourney is done."""
-    return datetime.timezone.utc - datetime.timedelta(hours=1)
+    return datetime.datetime.now(datetime.UTC) - datetime.timedelta(hours=1)
 
 
 def get_date_offset() -> int:

--- a/thetower/dtower/tourney_results/get_results.py
+++ b/thetower/dtower/tourney_results/get_results.py
@@ -22,7 +22,7 @@ logging.basicConfig(level=logging.INFO)
 
 def get_current_time__game_server():
     """Game server runs on utc time, but we don't want to try accessing results until 1 hour after the tourney is done."""
-    return datetime.datetime.utcnow() - datetime.timedelta(hours=1)
+    return datetime.timezone.utc - datetime.timedelta(hours=1)
 
 
 def get_date_offset() -> int:


### PR DESCRIPTION
Reusing the end of tourney import meant there's a built in hour delay on top of the 30 minute delay designed for live results.  As a result, trends are 90 minutes lagged.  Let's get rid of the hour and make it just the 30 minutes.