### PR TITLE
Keep home as an environmental variable so it can be overridden

### DIFF
--- a/components/live_score.py
+++ b/components/live_score.py
@@ -90,9 +90,8 @@ Your summary starts now."""
 
 
 def get_live_df(league):
-    home = Path.home()
     league_folder = us_to_jim[league]
-    live_path = home / "tourney" / "results_cache" / f"{league_folder}_live"
+    live_path = Path(f"{os.getenv('HOME')}/tourney/results_cache/{league_folder}_live")
 
     all_files = sorted(live_path.glob("*.csv"))
     last_file = all_files[-1]

--- a/thetower/dtower/tourney_results/import/import_results.py
+++ b/thetower/dtower/tourney_results/import/import_results.py
@@ -34,7 +34,7 @@ while True:
             continue
 
         logging.info("Something new")
-        last_files = sorted([file_name for file_name in glob(f"/root/tourney/results_cache/{us_to_jim[league]}/{last_date}*") if "csv_raw" not in file_name])
+        last_files = sorted([file_name for file_name in glob(f"{os.getenv('HOME')}/tourney/results_cache/{us_to_jim[league]}/{last_date}*") if "csv_raw" not in file_name])
 
         if not last_files:
             logging.info("Apparently we're checking the files before the download script could get them, try later.")


### PR DESCRIPTION
osenv variables can all be overridden via .env or other means, which means for test purposes, we can run multiple concurrent test versions with different data on the same machine.